### PR TITLE
Use autoconf213 instead of homebrew/versions/autoconf213

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Utilities:<br>
 
 Install dependencies with homebrew http://brew.sh:
 
-	brew install wget node cmake yasm homebrew/versions/autoconf213 
+	brew install wget node cmake yasm autoconf213 
 
 ### Ubuntu / Travis
 

--- a/config.js
+++ b/config.js
@@ -22,7 +22,7 @@ module.exports = {
         mozilla_config: 'mozilla-config.h',
         url: 'https://hg.mozilla.org/mozilla-central/archive/',
         version: 'FIREFOX_AURORA_52_BASE',
-        format: '.tar.gz',
+        format: '.zip',
         arch: 'x86_64', // i386, x86_64
         packages: {
             general: [


### PR DESCRIPTION
homebrew/versions has been deprecated. See details in: https://docs.brew.sh/Versions